### PR TITLE
Publish New Versions (feature/meta_data_property)

### DIFF
--- a/.changes/meta_data.md
+++ b/.changes/meta_data.md
@@ -1,6 +1,0 @@
----
-"tauri-plugin-medialibrary-js": minor
----
-
-- Added a metadata property to the ImageInfo result structure
-- Updated tauri dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.4.0]
+
+- [`7881440`](https://github.com/universalappfactory/tauri-plugin-medialibrary/commit/7881440906b8406e40d4e5160dd93db5abf529f7) -   Added a metadata property to the ImageInfo result structure
+  - Updated tauri dependencies
+
 ## \[0.3.0]
 
 - [`e5030ec`](https://github.com/universalappfactory/tauri-plugin-medialibrary/commit/e5030ecde76c8700b877822ee8c612db3b471829) -   updated @tauri-apps/api dependency to 2.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universalappfactory/tauri-plugin-medialibrary",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Dirk Lehmeier",
   "description": "",
   "type": "module",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# tauri-plugin-medialibrary-js

## [0.4.0]
- 7881440 -   Added a metadata property to the ImageInfo result structure
    -   Updated tauri dependencies