### PR TITLE
Publish New Versions (main)

### DIFF
--- a/.changes/package_update.md
+++ b/.changes/package_update.md
@@ -1,6 +1,0 @@
----
-"tauri-plugin-medialibrary-js": minor
----
-
-- updated tauri to 2.8.5
-- updated tauri-plugin to 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.8.0]
+
+- [`1cf0213`](https://github.com/universalappfactory/tauri-plugin-medialibrary/commit/1cf02130d572df5a567dabc65623140e5d03e958) -   updated tauri to 2.8.5
+  - updated tauri-plugin to 2.4.0
+
 ## \[0.7.0]
 
 - [`b492bda`](https://github.com/universalappfactory/tauri-plugin-medialibrary/commit/b492bdaef95593c636f9eb2317322153995f7693) -   Added additional metadata fields with data from the media file itself

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universalappfactory/tauri-plugin-medialibrary",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Dirk Lehmeier",
   "description": "",
   "type": "module",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# tauri-plugin-medialibrary-js

## [0.8.0]
- 1cf0213 -   updated tauri to 2.8.5
    -   updated tauri-plugin to 2.4.0