### PR TITLE
Publish New Versions (main)

### DIFF
--- a/.changes/dependency_update.md
+++ b/.changes/dependency_update.md
@@ -1,5 +1,0 @@
----
-"tauri-plugin-medialibrary-js": minor
-"tauri-plugin-medialibrary": minor
----
-- upgrade to latest tauri version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## \[0.16.0]
+
+- [`3bdd331`](https://github.com/universalappfactory/tauri-plugin-medialibrary/commit/3bdd3310338963471185219ddbd10cf59faf6e31) -   upgrade to latest tauri version
+
 ## \[0.15.0]
 
 - ## [`50cbb6d`](https://github.com/universalappfactory/tauri-plugin-medialibrary/commit/50cbb6d7708f55a50a6d789d7d638bf450f538ff) -   Added custom protocol handlers in order to load images using <img src="..." /> (check the ReadMe.md)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-medialibrary"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Dirk Lehmeier"]
 edition = "2021"
 rust-version = "1.77.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universalappfactory/tauri-plugin-medialibrary",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": "Dirk Lehmeier",
   "description": "A tauri plugin to access the systems media library (e.g. the android medialibrary)",
   "type": "module",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# tauri-plugin-medialibrary-js

## [0.13.0]
- 3bdd331 -   upgrade to latest tauri version



# tauri-plugin-medialibrary

## [0.16.0]
- 3bdd331 -   upgrade to latest tauri version